### PR TITLE
Refactor sidebar permissions and loading

### DIFF
--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -15,69 +15,101 @@ import { checkUserPermissions } from "@/lib/actions/auth/signIn"
 import Loading from "@/app/(auth)/loading"
 import { getUserWithProfile } from "@/lib/actions/user-actions"
 
-
 interface NavItem {
   title: string;
   url: string;
-  requiredPermission?: string; // Make it optional with the ? mark
+  requiredPermission?: string;
 }
 
 interface NavCategory {
   title: string;
   url: string;
-  icon: any; // You might want to define a more specific type for your icons
+  icon: any;
   items: NavItem[];
   isActive?: boolean;
 }
+
+interface PermissionsResponse {
+  role_id: string;
+  is_admin: boolean;
+  role_name: string;
+  permissions: Array<{
+    id: string;
+    name: string;
+    slug: string;
+    description: string | null;
+  }>;
+  permission_slugs: string[];
+}
+
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
-  const [permissions, setPermissions] = React.useState<string[]>([])
+  const [userPermissions, setUserPermissions] = React.useState<PermissionsResponse | null>(null)
   const [isLoading, setIsLoading] = React.useState(true)
   const [user, setUser] = React.useState<any>(null)
 
   React.useEffect(() => {
-    const fetchPermissions = async () => {
-      const { permissions, error } = await checkUserPermissions()
-      const user = await getUserWithProfile()
+    const fetchData = async () => {
+      try {
+        const { permissions, error } = await checkUserPermissions()
+        const user = await getUserWithProfile()
 
-      // console.log("The permissions", permissions)
-      if (error) {
-        console.error("Permission error:", error)
+        if (error) {
+          console.error("Permission error:", error)
+        }
+
+        setUserPermissions(permissions as PermissionsResponse)
+        setUser(user)
+      } catch (error) {
+        console.error("Error fetching data:", error)
+      } finally {
+        setIsLoading(false)
       }
-      setPermissions(permissions || [])
-      setUser(user)
-      setIsLoading(false)
     }
 
-    fetchPermissions()
+    fetchData()
   }, [])
 
   // Filter navigation items based on user permissions
-  const filteredNavItems = data.navMain
-  .map((category: NavCategory) => ({
-    ...category,
-    items: category.items.filter(
-      (item: NavItem) => item.requiredPermission ? permissions.includes(item.requiredPermission) : true
-    ),
-  }))
-  .filter((category) => category.items.length > 0)
+  const filteredNavItems = React.useMemo(() => {
+    if (!userPermissions) return []
 
-    // console.log(filteredNavItems)
+    return data.navMain
+        .map((category: NavCategory) => ({
+          ...category,
+          items: category.items.filter((item: NavItem) => {
+            // If no permission required, always show
+            if (!item.requiredPermission) return true
 
-  if (isLoading) return <div>
-    <Loading />
-  </div>
+            // If user is admin, show everything
+            if (userPermissions.is_admin) return true
+
+            // Check if user has the required permission slug
+            return userPermissions.permission_slugs?.includes(item.requiredPermission) || false
+          }),
+        }))
+        .filter((category) => category.items.length > 0)
+  }, [userPermissions])
+
+  if (isLoading) {
+    return (
+        <div className="h-screen flex items-center justify-center">
+          <Loading />
+        </div>
+    )
+  }
 
   return (
-    <Sidebar collapsible="icon" {...props}>
-      <SidebarHeader>
-        <CompanyDetail user={user}/>
-      </SidebarHeader>
-      <SidebarContent>
-        <NavMain items={filteredNavItems} />
-      </SidebarContent>
-      <SidebarFooter>
-      </SidebarFooter>
-      <SidebarRail />
-    </Sidebar>
+      <Sidebar collapsible="icon" {...props}>
+        <SidebarHeader>
+          <CompanyDetail user={user} />
+        </SidebarHeader>
+        <SidebarContent>
+          <NavMain items={filteredNavItems} />
+        </SidebarContent>
+        <SidebarFooter>
+          {/* Footer content if needed */}
+        </SidebarFooter>
+        <SidebarRail />
+      </Sidebar>
   )
 }

--- a/lib/actions/auth/signIn.tsx
+++ b/lib/actions/auth/signIn.tsx
@@ -209,7 +209,7 @@ export const SignIn = async (
         }
         const user = data.user;
 
-        // console.log("The user", user)
+        console.log("The user", user)
 
         const { data: internal_profile, error: profileError } = await supabase
             .from('internal_profiles')
@@ -229,7 +229,7 @@ export const SignIn = async (
         })
 
 
-        // console.log("The profile", internal_profile)
+        console.log("The profile", internal_profile)
 
         if (profileError) {
             console.log("The error", profileError)


### PR DESCRIPTION
Add a typed PermissionsResponse and rename state to userPermissions; fetch permissions and user inside a try/catch/finally flow and set isLoading correctly. Use useMemo to filter nav items by permission_slugs, allow admins to see all items, and center the Loading indicator. Minor JSX/formatting cleanup in Sidebar. Also enable console logging of user and profile in signIn for debugging.